### PR TITLE
Fix: Logout end-point Http Method GET으로 변경

### DIFF
--- a/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/controller/LoginController.java
+++ b/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/controller/LoginController.java
@@ -13,10 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -39,7 +36,7 @@ public class LoginController {
         }
     }
 
-    @PostMapping("/users/logout")
+    @GetMapping("/users/logout")
     public String logout(HttpServletRequest request, HttpServletResponse response){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null){


### PR DESCRIPTION
기존에는 로그아웃이 cookie 값을 변동 시킨다고 그래서 일반적으로 post를 사용한다고 했지만

회원정보 변경 시에 인증 정보 변경으로 인한 재 로그인이 필요하기 때문에 redirect를 거는게 더 편하다고 생각했음

근데 response.sendRedirect()를 사용하기 위해서는 해당 end-point가 GET 함수를 사용해야 가능하다고 해서 변경하게 됨