### PR TITLE
Fix: Post의 scrapCnt 필드 삭제

### DIFF
--- a/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/domain/community/board/Post.java
+++ b/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/domain/community/board/Post.java
@@ -32,14 +32,9 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
     private int viewCnt;
-    private int scrapCnt;
     @Transactional
     public void increaseView(){
         this.viewCnt+=1;
-    }
-    @Transactional
-    public void increaseScrap(){
-        this.scrapCnt++;
     }
 
     public Post(Member writer, String title, Tag tag, String content) {
@@ -49,7 +44,6 @@ public class Post {
         this.content = content;
         this.createdAt = LocalDateTime.now();
         this.viewCnt = 0;
-        this.scrapCnt = 0;
     }
     public void update(UpdatePostDTO updatePostDTO){
         this.title = updatePostDTO.getTitle();

--- a/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/dto/community/post/response/ShowPostDetailDTO.java
+++ b/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/dto/community/post/response/ShowPostDetailDTO.java
@@ -13,17 +13,15 @@ public class ShowPostDetailDTO {
     private String tag;
     private String content;
     private int viewCnt;
-    private int scrapCnt;
     private List<ShowCommentDTO> comments;
 
-    public ShowPostDetailDTO(Long id, String title, String writer, String tag, String content, int viewCnt, int scrapCnt, List<ShowCommentDTO> comments) {
+    public ShowPostDetailDTO(Long id, String title, String writer, String tag, String content, int viewCnt, List<ShowCommentDTO> comments) {
         this.postId = id;
         this.title = title;
         this.writer = writer;
         this.tag = tag;
         this.content = content;
         this.viewCnt = viewCnt;
-        this.scrapCnt = scrapCnt;
         this.comments = comments;
     }
 }

--- a/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/dto/community/post/response/ShowPostSimpleDTO.java
+++ b/FindOwn-v2/src/main/java/Farm/Team4/FindOwnv2/dto/community/post/response/ShowPostSimpleDTO.java
@@ -13,9 +13,8 @@ public class ShowPostSimpleDTO {
     private LocalDateTime createdAt;
     private int commentCnt;
     private int viewCnt;
-    private int scrapCnt;
 
-    public ShowPostSimpleDTO(Long postId, String title, String writerId, String tagName, LocalDateTime createdAt, int commentCnt, int viewCnt, int scrapCnt) {
+    public ShowPostSimpleDTO(Long postId, String title, String writerId, String tagName, LocalDateTime createdAt, int commentCnt, int viewCnt) {
         this.postId = postId;
         this.title = title;
         this.writerId = writerId;
@@ -23,6 +22,5 @@ public class ShowPostSimpleDTO {
         this.createdAt = createdAt;
         this.commentCnt = commentCnt;
         this.viewCnt = viewCnt;
-        this.scrapCnt = scrapCnt;
     }
 }


### PR DESCRIPTION
Post는 스크랩되는 객체가 아님!